### PR TITLE
Set selected candidate pair

### DIFF
--- a/index.html
+++ b/index.html
@@ -776,33 +776,7 @@ dictionary RTCEncodingOptions {
       </li>
       <li>
         <p>
-          Otherwise, set |transport|.{{RTCIceTransport/[[CandidatePairNominated]]}} to <code>true</code> and instruct the [=
-          ICE
-          agent =] to {{nominate}} the candidate pair indicated by |candidatePair|.
-        </p>
-      </li>
-    </ol>
-    <p>
-      When the [= ICE agent =] indicates that the {{nomination}} process has concluded, the [= user agent =] MUST queue a
-      task
-      that runs
-      the following steps:
-    </p>
-    <ol class="algorithm">
-      <li>
-        <p>
-          Let |transport:RTCIceTransport| be the {{RTCIceTransport}} object associated with this [= ICE agent =].
-        </p>
-      </li>
-      <li>
-        <p>
-          If the nomination is successful, continue to the steps for a change in the selected candidate pair.
-        </p>
-      </li>
-      <li>
-        <p>
-          If the nomination fails, set |transport|.{{RTCIceTransport/[[CandidatePairNominated]]}} to false. The selected
-          candidate pair has not changed in this case.
+          Otherwise, instruct the [= ICE agent =] to {{nominate}} the candidate pair indicated by |candidatePair|.
         </p>
       </li>
     </ol>
@@ -845,13 +819,6 @@ dictionary RTCEncodingOptions {
         <p>
           If <var>transport</var>.{{RTCIceTransport/[[IceRole]]}} is {{RTCIceRole/"unknown"}}, [= exception/throw =] an
           {{InvalidStateError}}.
-        </p>
-      </li>
-      <li>
-        <p>
-          If <var>transport</var>.{{RTCIceTransport/[[CandidatePairNominated]]}} is <code>true</code>, [= exception/throw
-          =]
-          an {{InvalidStateError}}.
         </p>
       </li>
       <li>
@@ -914,8 +881,7 @@ dictionary RTCEncodingOptions {
       </li>
       <li>
         <p>
-          Let |cancelable:boolean| be <code>true</code> if |transport|.{{RTCIceTransport/[[CandidatePairNominated]]}} is
-          <code>false</code> and the candidate pair is being removed in order to free an unused candidate, and
+          Let |cancelable:boolean| be <code>true</code> if the candidate pair is being removed in order to free an unused candidate, and
           <code>false</code> otherwise.
         </p>
       </li>
@@ -952,12 +918,9 @@ dictionary RTCEncodingOptions {
       </li>
     </ol>
     <p>
-      The {{RTCIceTransport}} object is extended by adding the following internal slots:
+      The {{RTCIceTransport}} object is extended by adding the following internal slot:
     </p>
     <ul>
-      <li>
-        <dfn data-dfn-for="RTCIceTransport">[[\CandidatePairNominated]]</dfn> initialized to <code>false</code>.
-      </li>
       <li>
         <dfn data-dfn-for="RTCIceTransport">[[\ProposalPending]]</dfn> initialized to <code>false</code>.
       </li>

--- a/index.html
+++ b/index.html
@@ -755,14 +755,104 @@ dictionary RTCEncodingOptions {
           If |accepted| is <code>false</code>, instruct the [= ICE agent =] to not {{nominate}} |candidatePair|, and instead
           to continue to perform connectivity checks. The [= ICE agent =] may exchange packets using the candidate pair
           indicated by |candidatePair| unless instructed to use another candidate pair with
-          <var>setSelectedCandidatePair</var>.
+          {{RTCIceTransport/setSelectedCandidatePair}}.
+          </p>
+      </li>
+      <li>
+        <p>
+          Otherwise, set |transport|.{{RTCIceTransport/[[CandidatePairNominated]]}} to <var>true</var> and instruct the [= ICE
+          agent =] to {{nominate}} the candidate pair indicated by |candidatePair|.
+        </p>
+      </li>
+    </ol>
+    <p>
+      When the [= ICE agent =] indicates that the {{nomination}} process has concluded, the [= user agent =] MUST queue a task
+      that runs
+      the following steps:
+    </p>
+    <ol class="algorithm">
+      <li>
+        <p>
+          Let |transport:RTCIceTransport| be the {{RTCIceTransport}} object associated with this [= ICE agent =].
         </p>
       </li>
       <li>
         <p>
-          Otherwise, instruct the [= ICE agent =] to {{nominate}} the candidate pair indicated by |candidatePair|. If the
-          nomination succeeds, |candidatePair| will become the selected candidate pair and be exclusively used for
-          exchanging packets. Changing the selected candidate pair will require an ICE restart.
+          If the nomination is successful, continue to the steps for a change in the selected candidate pair.
+        </p>
+      </li>
+      <li>
+        <p>
+          If the nomination fails, set |transport|.{{RTCIceTransport/[[CandidatePairNominated]]}} to false. The selected
+          candidate pair has not changed in this case.
+        </p>
+      </li>
+    </ol>
+    <p>
+      If the application defers the {{nomination}} of a candidate pair by cancelling the
+      {{RTCIceTransport/icecandidatepairnominate}} event, it may select a different candidate pair to exchange packets by
+      calling
+      {{RTCIceTransport/setSelectedCandidatePair}}. When the method is called, the [= user agent =] MUST run the steps to
+      <dfn id="rtcicetransport-select">change the selected candidate pair</dfn>:
+    </p>
+    <ol class="algorithm">
+      <li>
+        <p>
+          Let |connection:RTCPeerConnection| be the {{RTCPeerConnection}} object associated with this [= ICE agent =].
+        </p>
+      </li>
+      <li>
+        <p>
+          If <var>connection</var>.{{RTCPeerConnection/[[IsClosed]]}} is
+          <code>true</code>, [= exception/throw =] an {{InvalidStateError}}.
+        </p>
+      </li>
+      <li>
+        <p>
+          Let |transport:RTCIceTransport| be the {{RTCIceTransport}} object associated with this candidate pair.
+        </p>
+      </li>
+      <li>
+        <p>
+          If <var>transport</var>.{{RTCIceTransport/[[IceRole]]}} is {{RTCIceRole/"controlled"}}, [= exception/throw =] a
+          {{NotAllowedError}}.
+        </p>
+      </li>
+      <li>
+        <p>
+          If <var>transport</var>.{{RTCIceTransport/[[IceRole]]}} is {{RTCIceRole/"unknown"}}, [= exception/throw =] an
+          {{InvalidStateError}}.
+        </p>
+      </li>
+      <li>
+        <p>
+          If <var>transport</var>.{{RTCIceTransport/[[CandidatePairNominated]]}} is <code>true</code>, [= exception/throw =]
+          an {{InvalidStateError}}.
+        </p>
+      </li>
+      <li>
+        <p>
+          If |transport|.{{RTCIceTransport/[[IceTransportState]]}} is either of
+          {{RTCIceTransportState/"new"}}, {{RTCIceTransportState/"failed"}} or {{RTCIceTransportState/"closed"}}, [= exception/throw =]
+          an {{InvalidStateError}}.
+        </p>
+      </li>
+      <li>
+        <p>
+          Let |candidatePair:RTCIceCandidatePair| be the candidate pair which is being set as the selected candidate pair.
+        </p>
+      </li>
+      <li>
+        <p>
+          If |candidatePair| does not describe a candidate pair formed for this {{RTCIceTransport}} and sent in
+          {{RTCIceTransport/onicecandidatepairadd}}, [= exception/throw =] a {{NotFoundError}}.
+        </p>
+      </li>
+      <li>
+        <p>
+          Instruct the [= ICE agent =] to use |candidatePair| to send and receive packets, and continue to the steps for a
+          change in the selected candidate pair (leading up to
+          {{RTCIceTransport/onselectedcandidatepairchange}}).
         </p>
       </li>
     </ol>
@@ -814,11 +904,20 @@ dictionary RTCEncodingOptions {
         </p>
       </li>
     </ol>
+    <p>
+      The {{RTCIceTransport}} object is extended by adding the following internal slot:
+    </p>
+    <ul>
+      <li>
+        <dfn data-dfn-for="RTCIceTransport">[[\CandidatePairNominated]]</dfn> initialized to <var>false</var>.
+      </li>
+    </ul>
     <pre class="idl">
       partial interface RTCIceTransport {
         attribute EventHandler onicecandidatepairadd;
         attribute EventHandler onicecandidatepairremove;
         attribute EventHandler onicecandidatepairnominate;
+        undefined setSelectedCandidatePair(RTCIceCandidatePair candidatePair);
       };</pre>
     <section>
       <h2>Attributes</h2>
@@ -859,10 +958,25 @@ dictionary RTCEncodingOptions {
             When the [= ICE agent =] has picked a candidate pair to {{nominate}} as the selected candidate pair, but before the
             nomination takes place, the [= user agent =] MUST run the steps to [= nominate a candidate pair =].
           </p>
-        </dd>
-      </dl>
-    </section>
-    <section>
+          </dd>
+          </dl>
+          </section>
+          <section>
+            <h2>Methods</h2>
+            <dl data-link-for="RTCIceTransport" data-dfn-for="RTCIceTransport" class="methods">
+              <dt>
+                <dfn>setSelectedCandidatePair</dfn>
+              </dt>
+              <dd>
+                <p>
+                  The {{setSelectedCandidatePair}} method attempts to change the selected candidate pair. If successful, packets will be
+                  sent and received on the provided candidate pair. When this method is invoked, the [= user agent =] must run the
+                  steps to [= change the selected candidate pair =].
+                </p>
+              </dd>
+              </dl>
+              </section>
+      <section>
       <h2>
         <dfn>RTCIceCandidatePairEvent</dfn>
       </h2>

--- a/index.html
+++ b/index.html
@@ -748,11 +748,21 @@ dictionary RTCEncodingOptions {
       </li>
       <li>
         <p>
+          Set |transport|.{{RTCIceTransport/[[ProposalPending]]}} to <code>true</code>.
+        </p>
+      </li>
+      <li>
+        <p>
           Let |accepted:boolean| be the result of [= fire an event | firing an event =] named
           {{RTCIceTransport/icecandidatepairnominate}} at |transport|, using {{RTCIceCandidatePairEvent}}, with the
           {{Event/cancelable}} attribute initialized to <var>true</var>, and the {{RTCIceCandidatePairEvent/local}} and
           {{RTCIceCandidatePairEvent/remote}} attributes initialized to the local and remote candidates, respectively, of
           |candidatePair|.
+        </p>
+      </li>
+      <li>
+        <p>
+          Set |transport|.{{RTCIceTransport/[[ProposalPending]]}} to <code>false</code>.
         </p>
       </li>
       <li>
@@ -818,6 +828,11 @@ dictionary RTCEncodingOptions {
       <li>
         <p>
           Let |transport:RTCIceTransport| be the {{RTCIceTransport}} object associated with this candidate pair.
+        </p>
+      </li>
+      <li>
+        <p>
+          If |transport|.{{RTCIceTransport/[[ProposalPending]]}} is <code>true</code>, [= exception/throw =] an {{InvalidStateError}}.
         </p>
       </li>
       <li>
@@ -906,11 +921,21 @@ dictionary RTCEncodingOptions {
       </li>
       <li>
         <p>
+          Set |transport|.{{RTCIceTransport/[[ProposalPending]]}} to <code>true</code>.
+        </p>
+      </li>
+      <li>
+        <p>
           Let |accepted:boolean| be the result of [= fire an event | firing an event =] named
           {{RTCIceTransport/icecandidatepairremove}} at |transport|, using {{RTCIceCandidatePairEvent}}, with the
           {{Event/cancelable}} attribute initialized to <var>cancelable</var>, and the {{RTCIceCandidatePairEvent/local}}
           and {{RTCIceCandidatePairEvent/remote}} attributes initialized to the local and remote candidates, respectively,
           of |candidatePair|.
+        </p>
+      </li>
+      <li>
+        <p>
+          Set |transport|.{{RTCIceTransport/[[ProposalPending]]}} to <code>false</code>.
         </p>
       </li>
       <li>
@@ -927,11 +952,14 @@ dictionary RTCEncodingOptions {
       </li>
     </ol>
     <p>
-      The {{RTCIceTransport}} object is extended by adding the following internal slot:
+      The {{RTCIceTransport}} object is extended by adding the following internal slots:
     </p>
     <ul>
       <li>
-        <dfn data-dfn-for="RTCIceTransport">[[\CandidatePairNominated]]</dfn> initialized to <var>false</var>.
+        <dfn data-dfn-for="RTCIceTransport">[[\CandidatePairNominated]]</dfn> initialized to <code>false</code>.
+      </li>
+      <li>
+        <dfn data-dfn-for="RTCIceTransport">[[\ProposalPending]]</dfn> initialized to <code>false</code>.
       </li>
     </ul>
     <pre class="idl">
@@ -996,7 +1024,7 @@ dictionary RTCEncodingOptions {
           <p>
             The {{setSelectedCandidatePair}} method attempts to change the selected candidate pair. If successful, packets
             will be
-            sent and received on the provided candidate pair. When this method is invoked, the [= user agent =] must run
+            sent and received on the provided candidate pair. When this method is invoked, the [= user agent =] MUST run
             the
             steps to [= change the selected candidate pair =].
           </p>

--- a/index.html
+++ b/index.html
@@ -709,15 +709,20 @@ dictionary RTCEncodingOptions {
       application to observe and affect certain actions that an <dfn>ICE agent</dfn> [[RFC5245]] performs.
     </p>
     <p>
-      The [= ICE agent =] performs connectivity checks to identify valid candidate pairs on which it is possible to send and
-      receive media and data. In order to conclude ICE processing, the [= ICE agent =] {{nominates}} a valid candidate pair
-      as the selected candidate pair. Prior to nomination, any valid candidate pair may be used to exchange packets. Once a
+      The [= ICE agent =] performs connectivity checks to identify valid candidate pairs on which it is possible to send
+      and
+      receive media and data. In order to conclude ICE processing, the [= ICE agent =] {{nominates}} a valid candidate
+      pair
+      as the selected candidate pair. Prior to nomination, any valid candidate pair may be used to exchange packets. Once
+      a
       candidate pair is nominated successfully, only the selected candidate pair may be used to exchange packets. Changing
       the selected candidate pair after a successful nomination requires an ICE restart.
     </p>
     <p>
-      When the [= ICE agent =] has picked a candidate pair to {{nominate}} as the selected candidate pair, the [= user agent =]
-      MUST [= queue a task =] to <dfn id="rtcicetransport-nominate" data-lt="nominate the candidate pair">nominate a candidate pair</dfn>:
+      When the [= ICE agent =] has picked a candidate pair to {{nominate}} as the selected candidate pair, the [= user
+      agent =]
+      MUST [= queue a task =] to <dfn id="rtcicetransport-nominate" data-lt="nominate the candidate pair">nominate a
+        candidate pair</dfn>:
     </p>
     <ol class="algorithm">
       <li>
@@ -752,21 +757,24 @@ dictionary RTCEncodingOptions {
       </li>
       <li>
         <p>
-          If |accepted| is <code>false</code>, instruct the [= ICE agent =] to not {{nominate}} |candidatePair|, and instead
+          If |accepted| is <code>false</code>, instruct the [= ICE agent =] to not {{nominate}} |candidatePair|, and
+          instead
           to continue to perform connectivity checks. The [= ICE agent =] may exchange packets using the candidate pair
           indicated by |candidatePair| unless instructed to use another candidate pair with
           {{RTCIceTransport/setSelectedCandidatePair}}.
-          </p>
+        </p>
       </li>
       <li>
         <p>
-          Otherwise, set |transport|.{{RTCIceTransport/[[CandidatePairNominated]]}} to <var>true</var> and instruct the [= ICE
+          Otherwise, set |transport|.{{RTCIceTransport/[[CandidatePairNominated]]}} to <var>true</var> and instruct the [=
+          ICE
           agent =] to {{nominate}} the candidate pair indicated by |candidatePair|.
         </p>
       </li>
     </ol>
     <p>
-      When the [= ICE agent =] indicates that the {{nomination}} process has concluded, the [= user agent =] MUST queue a task
+      When the [= ICE agent =] indicates that the {{nomination}} process has concluded, the [= user agent =] MUST queue a
+      task
       that runs
       the following steps:
     </p>
@@ -826,14 +834,16 @@ dictionary RTCEncodingOptions {
       </li>
       <li>
         <p>
-          If <var>transport</var>.{{RTCIceTransport/[[CandidatePairNominated]]}} is <code>true</code>, [= exception/throw =]
+          If <var>transport</var>.{{RTCIceTransport/[[CandidatePairNominated]]}} is <code>true</code>, [= exception/throw
+          =]
           an {{InvalidStateError}}.
         </p>
       </li>
       <li>
         <p>
           If |transport|.{{RTCIceTransport/[[IceTransportState]]}} is either of
-          {{RTCIceTransportState/"new"}}, {{RTCIceTransportState/"failed"}} or {{RTCIceTransportState/"closed"}}, [= exception/throw =]
+          {{RTCIceTransportState/"new"}}, {{RTCIceTransportState/"failed"}} or {{RTCIceTransportState/"closed"}}, [=
+          exception/throw =]
           an {{InvalidStateError}}.
         </p>
       </li>
@@ -857,10 +867,13 @@ dictionary RTCEncodingOptions {
       </li>
     </ol>
     <p class="note">
-      After changing the selected candidate pair, the [= ICE agent =] may attempt to [= nominate the candidate pair =] as well to conclude ICE processing. The application may cancel the nomination to allow further changes to the selected candidate pair.
+      After changing the selected candidate pair, the [= ICE agent =] may attempt to [= nominate the candidate pair =] as
+      well to conclude ICE processing. The application may cancel the nomination to allow further changes to the selected
+      candidate pair.
     </p>
     <p>
-      When the [= ICE agent =] has picked a candidate pair to remove, the [= user agent =] MUST [= queue a task =] to <dfn id="rtcicetransport-remove">remove a candidate pair</dfn>:
+      When the [= ICE agent =] has picked a candidate pair to remove, the [= user agent =] MUST [= queue a task =] to <dfn
+        id="rtcicetransport-remove">remove a candidate pair</dfn>:
     </p>
     <ol class="algorithm">
       <li>
@@ -886,19 +899,25 @@ dictionary RTCEncodingOptions {
       </li>
       <li>
         <p>
-          Let |cancelable:boolean| be <code>true</code> if |transport|.{{RTCIceTransport/[[CandidatePairNominated]]}} is <code>false</code> and the candidate pair is being removed in order to free an unused candidate, and <code>false</code> otherwise.
+          Let |cancelable:boolean| be <code>true</code> if |transport|.{{RTCIceTransport/[[CandidatePairNominated]]}} is
+          <code>false</code> and the candidate pair is being removed in order to free an unused candidate, and
+          <code>false</code> otherwise.
         </p>
       </li>
       <li>
         <p>
           Let |accepted:boolean| be the result of [= fire an event | firing an event =] named
           {{RTCIceTransport/icecandidatepairremove}} at |transport|, using {{RTCIceCandidatePairEvent}}, with the
-          {{Event/cancelable}} attribute initialized to <var>cancelable</var>, and the {{RTCIceCandidatePairEvent/local}} and {{RTCIceCandidatePairEvent/remote}} attributes initialized to the local and remote candidates, respectively, of |candidatePair|.
+          {{Event/cancelable}} attribute initialized to <var>cancelable</var>, and the {{RTCIceCandidatePairEvent/local}}
+          and {{RTCIceCandidatePairEvent/remote}} attributes initialized to the local and remote candidates, respectively,
+          of |candidatePair|.
         </p>
       </li>
       <li>
         <p>
-          If |accepted| is <code>false</code>, instruct the [= ICE agent =] to not remove the candidate pair indicated by |candidatePair|, and instead continue to send and respond to ICE connectivity checks on the candidate pair as before.
+          If |accepted| is <code>false</code>, instruct the [= ICE agent =] to not remove the candidate pair indicated by
+          |candidatePair|, and instead continue to send and respond to ICE connectivity checks on the candidate pair as
+          before.
         </p>
       </li>
       <li>
@@ -916,13 +935,13 @@ dictionary RTCEncodingOptions {
       </li>
     </ul>
     <pre class="idl">
-      partial interface RTCIceTransport {
-        attribute EventHandler onicecandidatepairadd;
-        attribute EventHandler onicecandidatepairremove;
-        attribute EventHandler onicecandidatepairnominate;
-        undefined setSelectedCandidatePair(RTCIceCandidatePair candidatePair);
-      };</pre>
-    <section>
+        partial interface RTCIceTransport {
+          attribute EventHandler onicecandidatepairadd;
+          attribute EventHandler onicecandidatepairremove;
+          attribute EventHandler onicecandidatepairnominate;
+          undefined setSelectedCandidatePair(RTCIceCandidatePair candidatePair);
+        };</pre>
+    <section id="rtcicetransport-attributes">
       <h2>Attributes</h2>
       <dl data-link-for="RTCIceTransport" data-dfn-for="RTCIceTransport" class="attributes">
         <dt>
@@ -935,7 +954,8 @@ dictionary RTCEncodingOptions {
           <p>
             When the [= ICE agent =] has formed a candidate pair, the [= user agent =] MUST queue a task to [= fire an
             event =] named {{icecandidatepairadd}} using the {{RTCIceCandidatePairEvent}} interface, with the
-            {{RTCIceCandidatePairEvent/local}} and {{RTCIceCandidatePairEvent/remote}} attributes set to the local and remote candidates, respectively, of the formed candidate pair.
+            {{RTCIceCandidatePairEvent/local}} and {{RTCIceCandidatePairEvent/remote}} attributes set to the local and
+            remote candidates, respectively, of the formed candidate pair.
           </p>
         </dd>
         <dt>
@@ -958,49 +978,54 @@ dictionary RTCEncodingOptions {
             The event type of this event handler is {{icecandidatepairnominate}}.
           </p>
           <p>
-            When the [= ICE agent =] has picked a candidate pair to {{nominate}} as the selected candidate pair, but before the
+            When the [= ICE agent =] has picked a candidate pair to {{nominate}} as the selected candidate pair, but
+            before
+            the
             nomination takes place, the [= user agent =] MUST run the steps to [= nominate a candidate pair =].
           </p>
-          </dd>
-          </dl>
-          </section>
-          <section>
-            <h2>Methods</h2>
-            <dl data-link-for="RTCIceTransport" data-dfn-for="RTCIceTransport" class="methods">
-              <dt>
-                <dfn>setSelectedCandidatePair</dfn>
-              </dt>
-              <dd>
-                <p>
-                  The {{setSelectedCandidatePair}} method attempts to change the selected candidate pair. If successful, packets will be
-                  sent and received on the provided candidate pair. When this method is invoked, the [= user agent =] must run the
-                  steps to [= change the selected candidate pair =].
-                </p>
-              </dd>
-              </dl>
-              </section>
-      <section>
+        </dd>
+      </dl>
+    </section>
+    <section id="rtcicetransport-methods">
+      <h2>Methods</h2>
+      <dl data-link-for="RTCIceTransport" data-dfn-for="RTCIceTransport" class="methods">
+        <dt>
+          <dfn>setSelectedCandidatePair</dfn>
+        </dt>
+        <dd>
+          <p>
+            The {{setSelectedCandidatePair}} method attempts to change the selected candidate pair. If successful, packets
+            will be
+            sent and received on the provided candidate pair. When this method is invoked, the [= user agent =] must run
+            the
+            steps to [= change the selected candidate pair =].
+          </p>
+        </dd>
+      </dl>
+    </section>
+    <section>
       <h2>
         <dfn>RTCIceCandidatePairEvent</dfn>
       </h2>
       <p>
-        The {{RTCIceTransport/icecandidatepairadd}} and {{RTCIceTransport/icecandidatepairremove}} events use the {{RTCIceCandidatePairEvent}} interface.
+        The {{RTCIceTransport/icecandidatepairadd}} and {{RTCIceTransport/icecandidatepairremove}} events use the
+        {{RTCIceCandidatePairEvent}} interface.
       </p>
       <div>
         <pre class="idl">[Exposed=Window]
-interface RTCIceCandidatePairEvent : Event {
-  constructor(DOMString type, RTCIceCandidatePairEventInit eventInitDict);
-  readonly attribute RTCIceCandidate local;
-  readonly attribute RTCIceCandidate remote;
-};</pre>
-        <section>
+  interface RTCIceCandidatePairEvent : Event {
+    constructor(DOMString type, RTCIceCandidatePairEventInit eventInitDict);
+    readonly attribute RTCIceCandidate local;
+    readonly attribute RTCIceCandidate remote;
+  };</pre>
+        <section id="rtcicecandidatepairevent-constructors">
           <h4>Constructors</h4>
           <dl data-link-for="RTCIceCandidatePairEvent" data-dfn-for="RTCIceCandidatePairEvent" class="constructors">
             <dt><dfn>RTCIceCandidatePairEvent.constructor()</dfn></dt>
             <dd></dd>
           </dl>
         </section>
-        <section>
+        <section id="rtcicecandidatepairevent-attributes">
           <h4>Attributes</h4>
           <dl data-link-for="RTCIceCandidatePairEvent" data-dfn-for="RTCIceCandidatePairEvent" class="attributes">
             <dt>
@@ -1008,7 +1033,8 @@ interface RTCIceCandidatePairEvent : Event {
             </dt>
             <dd>
               <p>
-                The {{local}} attribute represents the local {{RTCIceCandidate}} of the candidate pair associated with the event.
+                The {{local}} attribute represents the local {{RTCIceCandidate}} of the candidate pair associated with the
+                event.
               </p>
             </dd>
             <dt>
@@ -1016,7 +1042,8 @@ interface RTCIceCandidatePairEvent : Event {
             </dt>
             <dd>
               <p>
-                The {{remote}} attribute represents the remote {{RTCIceCandidate}} of the candidate pair associated with the event.
+                The {{remote}} attribute represents the remote {{RTCIceCandidate}} of the candidate pair associated with
+                the event.
               </p>
             </dd>
           </dl>
@@ -1024,10 +1051,10 @@ interface RTCIceCandidatePairEvent : Event {
       </div>
       <div>
         <pre class="idl">
-dictionary RTCIceCandidatePairEventInit : EventInit {
-  required RTCIceCandidate local;
-  required RTCIceCandidate remote;
-};</pre>
+  dictionary RTCIceCandidatePairEventInit : EventInit {
+    required RTCIceCandidate local;
+    required RTCIceCandidate remote;
+  };</pre>
         <section id="rtcicecandidatepaireventinit">
           <h4>Dictionary <dfn>RTCIceCandidatePairEventInit</dfn> Members</h4>
           <dl data-link-for="RTCIceCandidatePairEventInit" data-dfn-for="RTCIceCandidatePairEventInit"

--- a/index.html
+++ b/index.html
@@ -710,12 +710,11 @@ dictionary RTCEncodingOptions {
     </p>
     <p>
       The [= ICE agent =] performs connectivity checks to identify valid candidate pairs on which it is possible to send
-      and
-      receive media and data. In order to conclude ICE processing, the [= ICE agent =] {{nominates}} a valid candidate
-      pair
-      as the selected candidate pair. Prior to nomination, any valid candidate pair may be used to exchange packets. Once
-      a
-      candidate pair is nominated successfully, only the selected candidate pair may be used to exchange packets. Changing
+      and receive media and data. In order to conclude ICE processing, the [= ICE agent =] {{nominates}} a valid candidate
+      pair as the selected candidate pair. Prior to nomination, any valid candidate pair may be used to send and receive data.
+      Once
+      a candidate pair is nominated successfully, only the selected candidate pair will be used to send and receive data.
+      Changing
       the selected candidate pair after a successful nomination requires an ICE restart.
     </p>
     <p>
@@ -767,9 +766,8 @@ dictionary RTCEncodingOptions {
       </li>
       <li>
         <p>
-          If |accepted| is <code>false</code>, instruct the [= ICE agent =] to not {{nominate}} |candidatePair|, and
-          instead
-          to continue to perform connectivity checks. The [= ICE agent =] may exchange packets using the candidate pair
+          If |accepted| is <code>false</code>, instruct the [= ICE agent =] to not {{nominate}} |candidatePair|, and instead to
+          continue to perform connectivity checks. The [= ICE agent =] may continue to send data using the candidate pair
           indicated by |candidatePair| unless instructed to use another candidate pair with
           {{RTCIceTransport/setSelectedCandidatePair}}.
         </p>
@@ -782,10 +780,9 @@ dictionary RTCEncodingOptions {
     </ol>
     <p>
       If the application defers the {{nomination}} of a candidate pair by cancelling the
-      {{RTCIceTransport/icecandidatepairnominate}} event, it may select a different candidate pair to exchange packets by
-      calling
-      {{RTCIceTransport/setSelectedCandidatePair}}. When the method is called, the [= user agent =] MUST run the steps to
-      <dfn id="rtcicetransport-select">change the selected candidate pair</dfn>:
+      {{RTCIceTransport/icecandidatepairnominate}} event, it may select a different candidate pair to send data by calling
+      {{RTCIceTransport/setSelectedCandidatePair}}. When the method is called, the [= user agent =] MUST run the steps to <dfn
+        id="rtcicetransport-select">change the selected candidate pair</dfn>:
     </p>
     <ol class="algorithm">
       <li>
@@ -811,18 +808,6 @@ dictionary RTCEncodingOptions {
       </li>
       <li>
         <p>
-          If <var>transport</var>.{{RTCIceTransport/[[IceRole]]}} is {{RTCIceRole/"controlled"}}, [= exception/throw =] a
-          {{NotAllowedError}}.
-        </p>
-      </li>
-      <li>
-        <p>
-          If <var>transport</var>.{{RTCIceTransport/[[IceRole]]}} is {{RTCIceRole/"unknown"}}, [= exception/throw =] an
-          {{InvalidStateError}}.
-        </p>
-      </li>
-      <li>
-        <p>
           If |transport|.{{RTCIceTransport/[[IceTransportState]]}} is either of
           {{RTCIceTransportState/"new"}}, {{RTCIceTransportState/"failed"}} or {{RTCIceTransportState/"closed"}}, [=
           exception/throw =]
@@ -842,14 +827,14 @@ dictionary RTCEncodingOptions {
       </li>
       <li>
         <p>
-          Instruct the [= ICE agent =] to use |candidatePair| to send and receive packets, and continue to the steps for a
-          change in the selected candidate pair (leading up to
-          {{RTCIceTransport/onselectedcandidatepairchange}}).
+          Instruct the [= ICE agent =] to use |candidatePair| to send data, and continue to the steps for a change in the selected
+          candidate pair (leading up to {{RTCIceTransport/onselectedcandidatepairchange}}).
         </p>
       </li>
     </ol>
     <p class="note">
-      After changing the selected candidate pair, the [= ICE agent =] may attempt to [= nominate the candidate pair =] as
+      After changing the selected candidate pair, the controlling [= ICE agent =] may attempt to [= nominate the candidate
+      pair =] as
       well to conclude ICE processing. The application may cancel the nomination to allow further changes to the selected
       candidate pair.
     </p>
@@ -985,11 +970,9 @@ dictionary RTCEncodingOptions {
         </dt>
         <dd>
           <p>
-            The {{setSelectedCandidatePair}} method attempts to change the selected candidate pair. If successful, packets
-            will be
-            sent and received on the provided candidate pair. When this method is invoked, the [= user agent =] MUST run
-            the
-            steps to [= change the selected candidate pair =].
+            The {{setSelectedCandidatePair}} method attempts to change the selected candidate pair. If successful, data will be sent
+            on the provided candidate pair. When this method is invoked, the [= user agent =] MUST run the steps to [= change the
+            selected candidate pair =].
           </p>
         </dd>
       </dl>

--- a/index.html
+++ b/index.html
@@ -886,7 +886,7 @@ dictionary RTCEncodingOptions {
       </li>
       <li>
         <p>
-          Let |cancelable:boolean| be <code>true</code> if the candidate pair is being removed in order to free an unused candidate, and <code>false</code> otherwise.
+          Let |cancelable:boolean| be <code>true</code> if |transport|.{{RTCIceTransport/[[CandidatePairNominated]]}} is <code>false</code> and the candidate pair is being removed in order to free an unused candidate, and <code>false</code> otherwise.
         </p>
       </li>
       <li>

--- a/index.html
+++ b/index.html
@@ -74,6 +74,10 @@
     <p>
       The terms [= event =], [= event handlers =] and [= event handler event types =] are defined in [[!HTML]].
     </p>
+    <p>
+      The process of <dfn data-lt="nominate|nominated|nomination">nominating</dfn> a candidate pair is defined in
+      [[RFC8445]] Section 8.1.1.
+    </p>
   </section>
   <section id="ice-csp">
     <h3>
@@ -705,6 +709,64 @@ dictionary RTCEncodingOptions {
       application to observe and affect certain actions that an <dfn>ICE agent</dfn> [[RFC5245]] performs.
     </p>
     <p>
+      The [= ICE agent =] performs connectivity checks to identify valid candidate pairs on which it is possible to send and
+      receive media and data. In order to conclude ICE processing, the [= ICE agent =] {{nominates}} a valid candidate pair
+      as the selected candidate pair. Prior to nomination, any valid candidate pair may be used to exchange packets. Once a
+      candidate pair is nominated successfully, only the selected candidate pair may be used to exchange packets. Changing
+      the selected candidate pair after a successful nomination requires an ICE restart.
+    </p>
+    <p>
+      When the [= ICE agent =] has picked a candidate pair to {{nominate}} as the selected candidate pair, the [= user agent =]
+      MUST [= queue a task =] to <dfn id="rtcicetransport-nominate">nominate a candidate pair</dfn>:
+    </p>
+    <ol class="algorithm">
+      <li>
+        <p>
+          Let |connection:RTCPeerConnection| be the {{RTCPeerConnection}} object associated with this [= ICE agent =].
+        </p>
+      </li>
+      <li>
+        <p>
+          If <var>connection</var>.{{RTCPeerConnection/[[IsClosed]]}} is
+          <code>true</code>, abort these steps.
+        </p>
+      </li>
+      <li>
+        <p>
+          Let |transport:RTCIceTransport| be the {{RTCIceTransport}} object associated with this candidate pair.
+        </p>
+      </li>
+      <li>
+        <p>
+          Let |candidatePair:RTCIceCandidatePair| be the candidate pair which is being {{nominated}}.
+        </p>
+      </li>
+      <li>
+        <p>
+          Let |accepted:boolean| be the result of [= fire an event | firing an event =] named
+          {{RTCIceTransport/icecandidatepairnominate}} at |transport|, using {{RTCIceCandidatePairEvent}}, with the
+          {{Event/cancelable}} attribute initialized to <var>true</var>, and the {{RTCIceCandidatePairEvent/local}} and
+          {{RTCIceCandidatePairEvent/remote}} attributes initialized to the local and remote candidates, respectively, of
+          |candidatePair|.
+        </p>
+      </li>
+      <li>
+        <p>
+          If |accepted| is <code>false</code>, instruct the [= ICE agent =] to not {{nominate}} |candidatePair|, and instead
+          to continue to perform connectivity checks. The [= ICE agent =] may exchange packets using the candidate pair
+          indicated by |candidatePair| unless instructed to use another candidate pair with
+          <var>setSelectedCandidatePair</var>.
+        </p>
+      </li>
+      <li>
+        <p>
+          Otherwise, instruct the [= ICE agent =] to {{nominate}} the candidate pair indicated by |candidatePair|. If the
+          nomination succeeds, |candidatePair| will become the selected candidate pair and be exclusively used for
+          exchanging packets. Changing the selected candidate pair will require an ICE restart.
+        </p>
+      </li>
+    </ol>
+    <p>
       When the [= ICE agent =] has picked a candidate pair to remove, the [= user agent =] MUST [= queue a task =] to <dfn id="rtcicetransport-remove">remove a candidate pair</dfn>:
     </p>
     <ol class="algorithm">
@@ -756,6 +818,7 @@ dictionary RTCEncodingOptions {
       partial interface RTCIceTransport {
         attribute EventHandler onicecandidatepairadd;
         attribute EventHandler onicecandidatepairremove;
+        attribute EventHandler onicecandidatepairnominate;
       };</pre>
     <section>
       <h2>Attributes</h2>
@@ -783,6 +846,18 @@ dictionary RTCEncodingOptions {
           <p>
             When the [= ICE agent =] has picked a candidate pair to remove, but before the removal has actually occurred,
             the [= user agent =] MUST run the steps to [= remove a candidate pair =].
+          </p>
+        </dd>
+        <dt>
+          <dfn>onicecandidatepairnominate</dfn> of type <span class="idlAttrType">{{EventHandler}}</span>
+        </dt>
+        <dd>
+          <p>
+            The event type of this event handler is {{icecandidatepairnominate}}.
+          </p>
+          <p>
+            When the [= ICE agent =] has picked a candidate pair to {{nominate}} as the selected candidate pair, but before the
+            nomination takes place, the [= user agent =] MUST run the steps to [= nominate a candidate pair =].
           </p>
         </dd>
       </dl>
@@ -1298,6 +1373,14 @@ partial interface RTCRtpTransceiver {
           <td>{{RTCIceCandidatePairEvent}}</td>
           <td>
             The [= ICE agent =] has picked a candidate pair to remove, and unless the operation is canceled by invoking the <code>preventDefault()</code> method on the event, it will be removed.
+          </td>
+        </tr>
+        <tr>
+          <th scope=row><dfn data-dfn-for="RTCIceTransport" data-dfn-type=event>icecandidatepairnominate</dfn></th>
+          <td>{{RTCIceCandidatePairEvent}}</td>
+          <td>
+            The [= ICE agent =] has picked a valid candidate pair to {{nominate}}, and unless the operation is canceled by
+            invoking the <code>preventDefault()</code> method on the event, it will be {{nominated}}.
           </td>
         </tr>
       </tbody>

--- a/index.html
+++ b/index.html
@@ -717,7 +717,7 @@ dictionary RTCEncodingOptions {
     </p>
     <p>
       When the [= ICE agent =] has picked a candidate pair to {{nominate}} as the selected candidate pair, the [= user agent =]
-      MUST [= queue a task =] to <dfn id="rtcicetransport-nominate">nominate a candidate pair</dfn>:
+      MUST [= queue a task =] to <dfn id="rtcicetransport-nominate" data-lt="nominate the candidate pair">nominate a candidate pair</dfn>:
     </p>
     <ol class="algorithm">
       <li>
@@ -856,6 +856,9 @@ dictionary RTCEncodingOptions {
         </p>
       </li>
     </ol>
+    <p class="note">
+      After changing the selected candidate pair, the [= ICE agent =] may attempt to [= nominate the candidate pair =] as well to conclude ICE processing. The application may cancel the nomination to allow further changes to the selected candidate pair.
+    </p>
     <p>
       When the [= ICE agent =] has picked a candidate pair to remove, the [= user agent =] MUST [= queue a task =] to <dfn id="rtcicetransport-remove">remove a candidate pair</dfn>:
     </p>

--- a/index.html
+++ b/index.html
@@ -691,7 +691,7 @@ dictionary RTCEncodingOptions {
       <ul>
         <li>
           <p>For each <var>setParameterOptions.encodingOptions</var> indexed by <var>i</var>,
-          if <code><var>setParameterOptions.encodingOptions</var>[i].keyFrame</code> is set to <var>true</var>,
+          if <code><var>setParameterOptions.encodingOptions</var>[i].keyFrame</code> is set to <code>true</code>,
           request that the encoder associated with <code><var>parameters</var>.encodings[i]</code> generates a key frame.</p>
         </li>
       </ul>
@@ -755,7 +755,7 @@ dictionary RTCEncodingOptions {
         <p>
           Let |accepted:boolean| be the result of [= fire an event | firing an event =] named
           {{RTCIceTransport/icecandidatepairnominate}} at |transport|, using {{RTCIceCandidatePairEvent}}, with the
-          {{Event/cancelable}} attribute initialized to <var>true</var>, and the {{RTCIceCandidatePairEvent/local}} and
+          {{Event/cancelable}} attribute initialized to <code>true</code>, and the {{RTCIceCandidatePairEvent/local}} and
           {{RTCIceCandidatePairEvent/remote}} attributes initialized to the local and remote candidates, respectively, of
           |candidatePair|.
         </p>
@@ -776,7 +776,7 @@ dictionary RTCEncodingOptions {
       </li>
       <li>
         <p>
-          Otherwise, set |transport|.{{RTCIceTransport/[[CandidatePairNominated]]}} to <var>true</var> and instruct the [=
+          Otherwise, set |transport|.{{RTCIceTransport/[[CandidatePairNominated]]}} to <code>true</code> and instruct the [=
           ICE
           agent =] to {{nominate}} the candidate pair indicated by |candidatePair|.
         </p>


### PR DESCRIPTION
Fixes w3c/webrtc-extensions#171.

An event is proposed to defer the nomination of a candidate pair, thereby allowing the selected candidate pair to be changed without an ICE restart. A method is proposed to actually change the selected candidate pair.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sam-vi/webrtc-extensions/pull/2.html" title="Last updated on Oct 4, 2023, 1:03 PM UTC (403e85a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/sam-vi/webrtc-extensions/2/3ab7dbd...403e85a.html" title="Last updated on Oct 4, 2023, 1:03 PM UTC (403e85a)">Diff</a>