### PR TITLE
Validate removeCandidatePair input and update internal slot.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1071,7 +1071,12 @@ dictionary RTCEncodingOptions {
             </li>
             <li>
               <p>
-                If the {{RTCIceCandidatePair/local}} and {{RTCIceCandidatePair/remote}} attributes of <var>candidatePair</var> do not match a pairing of {{RTCIceCandidatePairEvent/local}} and {{RTCIceCandidatePairEvent/remote}} respectively sent in {{RTCIceTransport/onicecandidatepairadd}}, [= exception/throw =] a {{NotFoundError}}.
+                If |candidatePair| does not [= candidate pair match | match =] any item in [=this=].{{RTCIceTransport/[[CandidatePairs]]}}, [= exception/throw =] a {{NotFoundError}}.
+              </p>
+            </li>
+            <li>
+              <p>
+                [= list/Remove =] all items that [= candidate pair match | match =] |candidatePair| from [=this=].{{RTCIceTransport/[[CandidatePairs]]}}.
               </p>
             </li>
             <li>


### PR DESCRIPTION
This depends on several other PRs to be merged first:
- #170: Addition of removeCandidatePair method
- #192: Definition of candidate match algo
  - alternately, w3c/webrtc-pc#2906 to enforce RTCIceCandidate object equality
- #193: Definition of candidate pair match algo
- #194: Addition of CandidatePairs internal slot


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sam-vi/webrtc-extensions/pull/4.html" title="Last updated on Jan 12, 2024, 10:46 AM UTC (ecd06e1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/sam-vi/webrtc-extensions/4/d0d0ae1...ecd06e1.html" title="Last updated on Jan 12, 2024, 10:46 AM UTC (ecd06e1)">Diff</a>